### PR TITLE
disables line-length check on markdownlint

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -12,7 +12,8 @@ steps:
   - apk update
   - apk add npm curl jq
   - npm install -g markdownlint-cli
-  - markdownlint README.md
+  - echo '{"MD013": false}' | tee .markdownlint.json
+  - markdownlint -c .markdownlint.json README.md
   - if [  "$(curl -s -H "Authorization:token $GH_TOKEN" https://api.github.com/repos/jmarhee/github-repo-practices | jq .homepage)" = "null" ]; then echo "No homepage link set."; exit 1; fi   
   - if [  "$(curl -s -H "Authorization:token $GH_TOKEN" https://api.github.com/repos/jmarhee/github-repo-practices | jq .description)" = "null" ]; then echo "No description set."; exit 1; fi 
   - if [  "$(curl -s -H 'Accept:application/vnd.github.mercy-preview+json' https://api.github.com/repos/jmarhee/github-repo-practices/topics | jq '.names | length' | xargs echo)" = "0" ]; then echo "No topics set."; exit 1; fi

--- a/.drone.yml
+++ b/.drone.yml
@@ -10,9 +10,9 @@ steps:
       from_secret: GH_TOKEN
   commands:
   - apk update
-  - apk add npm curl jq
+  - apk add npm curl jq wget
   - npm install -g markdownlint-cli
-  - echo \"{\"MD013\": false}\" > .markdownlint.json
+  - wget "https://gist.githubusercontent.com/jmarhee/ce4ea07a58f2b29a7119a406727f5f1f/raw/dbf83ab3bd1746120defb845c479b7322618c70a/.markdownlint.json"
   - markdownlint -c .markdownlint.json README.md
   - if [  "$(curl -s -H "Authorization:token $GH_TOKEN" https://api.github.com/repos/jmarhee/github-repo-practices | jq .homepage)" = "null" ]; then echo "No homepage link set."; exit 1; fi   
   - if [  "$(curl -s -H "Authorization:token $GH_TOKEN" https://api.github.com/repos/jmarhee/github-repo-practices | jq .description)" = "null" ]; then echo "No description set."; exit 1; fi 

--- a/.drone.yml
+++ b/.drone.yml
@@ -12,7 +12,7 @@ steps:
   - apk update
   - apk add npm curl jq
   - npm install -g markdownlint-cli
-  - echo '{"MD013": false}' | tee .markdownlint.json
+  - echo "{\"MD013\": false}" > .markdownlint.json
   - markdownlint -c .markdownlint.json README.md
   - if [  "$(curl -s -H "Authorization:token $GH_TOKEN" https://api.github.com/repos/jmarhee/github-repo-practices | jq .homepage)" = "null" ]; then echo "No homepage link set."; exit 1; fi   
   - if [  "$(curl -s -H "Authorization:token $GH_TOKEN" https://api.github.com/repos/jmarhee/github-repo-practices | jq .description)" = "null" ]; then echo "No description set."; exit 1; fi 

--- a/.drone.yml
+++ b/.drone.yml
@@ -12,7 +12,7 @@ steps:
   - apk update
   - apk add npm curl jq
   - npm install -g markdownlint-cli
-  - echo "{\"MD013\": false}" > .markdownlint.json
+  - echo \"{\"MD013\": false}\" > .markdownlint.json
   - markdownlint -c .markdownlint.json README.md
   - if [  "$(curl -s -H "Authorization:token $GH_TOKEN" https://api.github.com/repos/jmarhee/github-repo-practices | jq .homepage)" = "null" ]; then echo "No homepage link set."; exit 1; fi   
   - if [  "$(curl -s -H "Authorization:token $GH_TOKEN" https://api.github.com/repos/jmarhee/github-repo-practices | jq .description)" = "null" ]; then echo "No description set."; exit 1; fi 


### PR DESCRIPTION
I don't know that a line-length rule for linting is going to be a good use of our time to correct habitually while including documentation of any kind is a priority-- I'd like to disable it for now on this project with existing documentation, rather than include this in the base ruleset. 